### PR TITLE
Add empty "files" (whitelist) field to not publish unwanted files

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "url": "https://github.com/iarna/unique-filename.git"
   },
   "keywords": [],
+  "files": [],
   "author": "Rebecca Turner <me@re-becca.org> (http://re-becca.org/)",
   "license": "ISC",
   "bugs": {


### PR DESCRIPTION
# What / Why
Add the "files" field in the package.json to avoid publishing unwanted files in the npm registry. Here:
- npmignore
- test

fix #1 
avoid doing a blacklist like #2 

Best Regards,
Thomas